### PR TITLE
Removed wrong archetype

### DIFF
--- a/content/theme/jekyll-j1-template.md
+++ b/content/theme/jekyll-j1-template.md
@@ -20,6 +20,7 @@ archetype:
 description: J1 - Create powerful modern static websites.
 ---
 
+
 # A fully configurable Jekyll Theme
 
 * Fully Responsive. J1 Template supports modern web browsers on all

--- a/content/theme/jekyll-j1-template.md
+++ b/content/theme/jekyll-j1-template.md
@@ -11,7 +11,8 @@ cms:
 css:
   - Bootstrap
 archetype:
-  - Website
+  - Personal
+  - Portfolio
   - Blog
   - Multi Purpose
   - Documentation

--- a/content/theme/jekyll-j1-template.md
+++ b/content/theme/jekyll-j1-template.md
@@ -1,7 +1,7 @@
 ---
 title: "J1 Template Starter"
 github: https://github.com/jekyll-one-org/j1-template-starter
-demo: https://jekyll-one-org.github.io/
+demo: https://j1-template-starter.netlify.app/
 author: Jürgen Adams
 date: 2021-04-01
 ssg:
@@ -19,7 +19,6 @@ archetype:
   - Business
 description: J1 - Create powerful modern static websites.
 ---
-
 
 # A fully configurable Jekyll Theme
 

--- a/content/theme/jekyll-j1-template.md
+++ b/content/theme/jekyll-j1-template.md
@@ -1,6 +1,6 @@
 ---
 title: "J1 Template Starter"
-github: https://github.com/jekyll-one-org/j1-template-starter
+github: https://github.com/jekyll-one/j1-template-starter
 demo: https://j1-template-starter.netlify.app/
 author: Jürgen Adams
 date: 2021-04-01


### PR DESCRIPTION
Hi there,

thanks a lot for pulling. I'd to remove an archetype because **NO** image is in behind. Another issue is the preview of the Live Demo. For my template, an **empty** page is displayed: [Live Demo](https://jamstackthemes.dev/demo/theme/jekyll-j1-template/).

I added a **new** demo page, created at **your** platform and claimed at **Netlify**: [j1-starter](https://j1-starter-dbc21.netlify.app/). Is it possible to link this page for a Live Demo?

Thanks,
Juergen 