### PR TITLE
Add information about gatsby-theme-amaranth and the Gatsby Advanced Starter.

### DIFF
--- a/content/theme/gatsby-starter-advanced.md
+++ b/content/theme/gatsby-starter-advanced.md
@@ -1,0 +1,82 @@
+---
+title: "Gatsby Advanced Starter"
+github: https://github.com/Vagr9K/gatsby-advanced-starter
+demo: https://gatsby-advanced-starter-demo.netlify.app/
+author: vagr9k
+date: 2021-08-09
+ssg:
+  - Gatsby
+cms:
+  - No CMS
+description: Gatsby Advanced Starter aims to provide a minimal base for building advanced GatsbyJS powered websites by using the latest technologies to simplify your process.
+---
+
+# A starter skeleton with advanced features
+
+The Advanced Starter doesn't define any UI limitations in any way and only gives you the basic components for SEO/Links/Infinite Scrolling while creating a comfortable development environment to get started.
+
+Starter supports both [TypeScript](https://www.typescriptlang.org/) and JavaScript, comes with [Jest](https://jestjs.io/) and [Cypress](https://www.cypress.io/) configurations and allows you to write Unit/Integration/E2E tests out of the box.
+
+You are free to use any UI framework/styling options or you can use the [`gatsby-theme-amaranth`](https://www.npmjs.com/package/gatsby-theme-amaranth) as a starting point, which provides a stylish blog design styled with [Styled Components](https://styled-components.com/)
+
+## Demos
+
+[With `gatsby-theme-advanced`](https://advanced-demo.netlify.app/)
+
+[With `gatsby-theme-amaranth`](https://amaranth-demo.netlify.app/).
+
+## Features
+
+- Gatsby v3 support
+- First class [TypeScript](https://www.typescriptlang.org/) support (for query data and components exposed by the theme)
+- Styled Components used for styling
+- Posts in MDX
+  - Code syntax highlighting
+  - Embed videos
+  - Embed iframes
+- Infinite Scrolling
+- React Query for client side API calls
+- Tags
+  - Separate page for posts under each tag
+- Categories
+  - Separate page for posts under each category
+- Social features
+  - Twitter tweet button
+  - Facebook share/share count
+  - Reddit share/share count
+  - LinkedIn share button
+- Author section
+- Related posts computation and display based on category/tag match ranking
+- [Disqus](https://disqus.com/) support
+- [gatsby-plugin-image](https://www.gatsbyjs.com/plugins/gatsby-plugin-image/) for optimized image generation
+- Inline SVG imports
+- High configurability
+- Separate components for everything:
+  - Gatsby Link utilities
+  - SEO
+  - Disqus
+- PWA features
+  - Offline support
+  - Web App Manifest support
+  - Loading progress for slow networks
+- SEO
+  - [Google gtag.js](https://developers.google.com/gtagjs/) support
+  - Sitemap generation
+  - General description tags
+  - [Google Structured Data](https://developers.google.com/search/docs/advanced/structured-data/intro-structured-data)
+  - [OpenGraph Tags (Facebook/Google+/Pinterest)](https://ogp.me/)
+  - [Twitter Tags (Twitter Cards)](https://developer.twitter.com/en/docs/tweets/optimize-with-cards/overview/markup)
+- RSS feeds
+- Development tools
+  - Yarn 3
+  - [Jest](https://jestjs.io/) for unit/integration testing
+  - [Cypress](https://www.cypress.io/) for E2E testing
+  - CI via GitHub Actions
+  - CD via GitHub Actions
+  - [ESLint](https://eslint.org/) for linting
+  - [Prettier](https://prettier.io/) for code formatting
+  - [React Hooks Linting](https://www.npmjs.com/package/eslint-plugin-react-hooks)
+  - Remark-Lint for linting Markdown
+  - write-good for linting English prose
+  - gh-pages for deploying to GitHub pages
+  - [Netlify](https://www.netlify.com/) deploy configuration

--- a/content/theme/gatsby-theme-amaranth.md
+++ b/content/theme/gatsby-theme-amaranth.md
@@ -1,0 +1,64 @@
+---
+title: "Amaranth"
+github: https://github.com/Vagr9K/gatsby-advanced-starter/tree/master/themes/amaranth
+demo: https://amaranth-demo.netlify.app/
+author: vagr9k
+date: 2021-08-09
+ssg:
+  - Gatsby
+cms:
+  - No CMS
+css:
+  - Styled Components
+archetype:
+  - Blog
+  - Portfolio
+description: Amaranth is a mobile optimized stylish blog theme for GatsbyJS, equipped with advanced features such as SEO, image optimization, PWA capabilities and infinite scrolling feeds.
+---
+
+# A starter theme for your blog
+
+Visit [`gatsby-theme-amaranth`](https://github.com/Vagr9K/gatsby-advanced-starter/tree/master/themes/amaranth) for details regarding on how it was built using [`gatsby-theme-advanced`](https://www.npmjs.com/package/gatsby-theme-advanced).
+
+## Features
+
+- Gatsby v3 support
+- First class TypeScript support (for query data and components exposed by the theme)
+- Styled Components used for styling
+- Posts in MDX
+  - Code syntax highlighting
+  - Embed videos
+  - Embed iframes
+- Infinite Scrolling
+- React Query for client side API calls
+- Tags
+  - Separate page for posts under each tag
+- Categories
+  - Separate page for posts under each category
+- Social features
+  - Twitter tweet button
+  - Facebook share/share count
+  - Reddit share/share count
+  - LinkedIn share button
+- Author section
+- Related posts computation and display based on category/tag match ranking
+- [Disqus](https://disqus.com/) support
+- [gatsby-plugin-image](https://www.gatsbyjs.com/plugins/gatsby-plugin-image/) for optimized image generation
+- Inline SVG imports
+- High configurability
+- Separate components for everything:
+  - Gatsby Link utilities
+  - SEO
+  - Disqus
+- PWA features
+  - Offline support
+  - Web App Manifest support
+  - Loading progress for slow networks
+- SEO
+  - [Google gtag.js](https://developers.google.com/gtagjs/) support
+  - Sitemap generation
+  - General description tags
+  - [Google Structured Data](https://developers.google.com/search/docs/advanced/structured-data/intro-structured-data)
+  - [OpenGraph Tags (Facebook/Google+/Pinterest)](https://ogp.me/)
+  - [Twitter Tags (Twitter Cards)](https://developer.twitter.com/en/docs/tweets/optimize-with-cards/overview/markup)
+- RSS feeds


### PR DESCRIPTION
Hello!

Thank you for creating a JamStack theme directory.

This PR adds information regarding the `gatsby-theme-amaranth` and the Gatsby Advanced Starter.

NOTE: Both are located in the same monorepo and the starter uses the Amaranth theme as a starting point, but the Amaranth theme can be used outside of the starter via the [npm package](https://www.npmjs.com/package/gatsby-theme-amaranth).