### PR TITLE
Create eleventy-theme-magazine.md with theme details

### DIFF
--- a/content/theme/eleventy-theme-magazine.md
+++ b/content/theme/eleventy-theme-magazine.md
@@ -1,0 +1,23 @@
+---
+title: "Eleventy Magazine Theme"
+github: https://github.com/exyone-js/eleventy-theme-magazine
+demo: https://exyon.ee
+author: exyone
+date: 2026-06-26
+ssg:
+  - Eleventy
+cms:
+  - No CMS
+css:
+  - Vanilla CSS
+archetype:
+  - Blog
+  - Magazine
+  - Portfolio
+description: >
+  A clean, text-focused, three-column magazine-style blog theme for Eleventy.
+  Includes dark mode, PWA support, client-side search, and optional comments.
+  
+  <img width="1850" height="995" alt="图片" src="https://github.com/user-attachments/assets/bd08e4af-2d4e-4c71-b889-a9be053929c6" />
+
+---


### PR DESCRIPTION
Added metadata and description for the Eleventy Magazine Theme.

the 'https://exyon.ee' is my site. demo is 'https://eleventy-theme-magazine.pages.dev' (it's to long, so i dont write it at the dome address, use my personal site instead)

by the way, i developed a new ssg: [Zest](https://github.com/zest-ssg/zest)

it's still in the pre-release stage, and no themes have been developed yet. may i ask if you would include an unstable ssg?